### PR TITLE
Fix VMMCALL in Hello2 JLM module

### DIFF
--- a/JLM/HELLO2/JLMW.ASM
+++ b/JLM/HELLO2/JLMW.ASM
@@ -9,7 +9,7 @@
 	.code
 
 Get_Cur_VM_Handle proc stdcall public uses ebx
-    VMMCall Get_Cur_VM_Handle
+    @VMMCall Get_Cur_VM_Handle
     mov eax, ebx
     ret
     align 4
@@ -17,14 +17,14 @@ Get_Cur_VM_Handle endp
 
 Begin_Nest_Exec proc stdcall public uses ebp pcl:ptr
     mov ebp,pcl
-    VMMCall Begin_Nest_Exec 
+    @VMMCall Begin_Nest_Exec
     ret
     align 4
 Begin_Nest_Exec endp
 
 End_Nest_Exec proc stdcall public uses ebp pcl:ptr
     mov ebp,pcl
-    VMMCall End_Nest_Exec
+    @VMMCall End_Nest_Exec
 	ret
     align 4
 End_Nest_Exec endp
@@ -32,7 +32,7 @@ End_Nest_Exec endp
 Exec_Int proc stdcall public uses ebp intno:dword, pcl:ptr
     mov eax, intno
     mov ebp,pcl
-    VMMCall Exec_Int
+    @VMMCall Exec_Int
     ret
     align 4
 Exec_Int endp


### PR DESCRIPTION
31a109756212f522ba06ec9495c7566512f69974 changed the macro name but neglected this file.
