### PR TITLE
Add script for Linux-hosted Open Watcom build

### DIFF
--- a/JLM/HELLO2/HELLO2W.C
+++ b/JLM/HELLO2/HELLO2W.C
@@ -3,8 +3,8 @@
 // OW inline assembly doesn't know values of enums!
 // therefore it needs external module jlmw.asm
 
-#include <jlm.h>
-#include "jlmw.h"
+#include <JLM.H>
+#include "JLMW.h"
 
 struct Client_Reg_Struc * pcl;
 

--- a/JLM/HELLO2/JLMW.ASM
+++ b/JLM/HELLO2/JLMW.ASM
@@ -4,7 +4,7 @@
 	.386
     .model flat
     
-	include jlm.inc
+	include JLM.INC
 
 	.code
 

--- a/JLM/HELLO2/makeow.sh
+++ b/JLM/HELLO2/makeow.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+# uses Open Watcom C, JWAsm and JWLink which must be in PATH
+# OW needs a helper module: jlmw.obj
+jwasm -I../../Include JLMW.ASM
+wcc386 -mf -zl -zls -s -I../../Include HELLO2W.C
+jwlink format win nt hx ru native file HELLO2W.o, JLMW.o name hello2w.exe option start=main_, map


### PR DESCRIPTION
Add script for Linux-hosted Open Watcom build and fix some case sensitivity issues.

It would also be possible to fix this by renaming the files to lowercase but that used to break git on Windows, not sure if that's been fixed.

Most of the files have DOS-style line endings which is slightly annoying on Linux but I didn't want to fix that since it creates very messy commits.
